### PR TITLE
Feature/2.7.0

### DIFF
--- a/appium/python/pytest/app/conftest.py
+++ b/appium/python/pytest/app/conftest.py
@@ -12,6 +12,7 @@ load_dotenv(str(Path(__file__).parent.parent / '.env.local'))
 
 localhost = "127.0.0.1"
 serial = os.environ.get("DOGU_DEVICE_SERIAL")
+token = os.environ.get("DOGU_DEVICE_TOKEN")
 app_path = os.environ.get("DOGU_APP_PATH")
 device_server_port = int(os.environ.get("DOGU_DEVICE_SERVER_PORT", 5001))
 device_gamium_server_port = 50061
@@ -25,13 +26,13 @@ pytest_plugins = ["pytest_dogu_report"]
 
 @pytest.fixture(scope="session")
 def device():
-    device_client = DeviceClient(localhost, device_server_port, 30)
+    device_client = DeviceClient(host=localhost, port=device_server_port, token=token, timeout=30)
     yield device_client
 
 
 @pytest.fixture(scope="session")
 def host():
-    host_client = DeviceHostClient(localhost, device_server_port, 30)
+    host_client = DeviceHostClient(host=localhost, port=device_server_port, token=token, timeout=30)
     yield host_client
 
 

--- a/appium/python/pytest/requirements.txt
+++ b/appium/python/pytest/requirements.txt
@@ -1,6 +1,6 @@
 Appium-Python-Client==3.1.0
 selenium==4.15.2
 python-dotenv==1.0.0
-dogu-device-client==1.1.0
+dogu-device-client==1.2.0rc1
 pytest==7.4.3
 pytest-dogu-sdk==1.0.5

--- a/appium/python/pytest/requirements.txt
+++ b/appium/python/pytest/requirements.txt
@@ -1,6 +1,6 @@
 Appium-Python-Client==3.1.0
 selenium==4.15.2
 python-dotenv==1.0.0
-dogu-device-client==1.0.0
+dogu-device-client==1.1.0
 pytest==7.4.3
 pytest-dogu-sdk==1.0.5

--- a/gamium/python/pytest/app/conftest.py
+++ b/gamium/python/pytest/app/conftest.py
@@ -14,6 +14,7 @@ load_dotenv(str(Path(__file__).parent.parent / '.env.local'))
 
 localhost = "127.0.0.1"
 serial = os.environ.get("DOGU_DEVICE_SERIAL")
+token = os.environ.get("DOGU_DEVICE_TOKEN")
 app_path = os.environ.get("DOGU_APP_PATH")
 device_server_port = int(os.environ.get("DOGU_DEVICE_SERVER_PORT", 5001))
 device_gamium_server_port = 50061
@@ -27,13 +28,13 @@ pytest_plugins = ["pytest_dogu_report"]
 
 @pytest.fixture(scope="session")
 def device():
-    device_client = DeviceClient(localhost, device_server_port, 30)
+    device_client = DeviceClient(host=localhost, port=device_server_port, token=token, timeout=30)
     yield device_client
 
 
 @pytest.fixture(scope="session")
 def host():
-    host_client = DeviceHostClient(localhost, device_server_port, 30)
+    host_client = DeviceHostClient(host=localhost, port=device_server_port, token=token, timeout=30)
     yield host_client
 
 

--- a/gamium/python/pytest/requirements.txt
+++ b/gamium/python/pytest/requirements.txt
@@ -1,7 +1,7 @@
 Appium-Python-Client==3.1.0
 selenium==4.15.2
 python-dotenv==1.0.0
-dogu-device-client==1.0.0
+dogu-device-client==1.1.0
 pytest==7.4.3
 pytest-dogu-sdk==1.0.5
 gamium==2.0.7

--- a/gamium/python/pytest/requirements.txt
+++ b/gamium/python/pytest/requirements.txt
@@ -1,7 +1,7 @@
 Appium-Python-Client==3.1.0
 selenium==4.15.2
 python-dotenv==1.0.0
-dogu-device-client==1.1.0
+dogu-device-client==1.2.0rc1
 pytest==7.4.3
 pytest-dogu-sdk==1.0.5
 gamium==2.0.7

--- a/gamium/typescript/jest/app/setup.ts
+++ b/gamium/typescript/jest/app/setup.ts
@@ -14,6 +14,7 @@ config({ path: ".env.local" });
 
 const Localhost = "127.0.0.1";
 const Serial = process.env["DOGU_DEVICE_SERIAL"];
+const Token = process.env["DOGU_DEVICE_TOKEN"];
 const AppPath = process.env["DOGU_APP_PATH"];
 const DeviceServerPort = parseInt(
   process.env["DOGU_DEVICE_SERVER_PORT"] ?? "5001"
@@ -35,7 +36,7 @@ let server: AppiumServerContext | undefined;
 let forwardClosable: DeviceCloser | undefined;
 
 beforeAll(async () => {
-  const device = new DeviceClient({ port: DeviceServerPort });
+  const device = new DeviceClient({ port: DeviceServerPort, token: Token });
   server = await device.runAppiumServer(Serial);
   const caps = await device.getAppiumCapabilities(Serial);
   caps["appium:app"] = AppPath;
@@ -54,7 +55,7 @@ beforeAll(async () => {
   await driver.dismissAlert().catch(() => {});
   await driver.acceptAlert().catch(() => {});
 
-  const host = new DeviceHostClient({ port: DeviceServerPort });
+  const host = new DeviceHostClient({ port: DeviceServerPort, token: Token });
   const gamiumHostPort = await host.getFreePort();
   forwardClosable = await device.forward(
     Serial,

--- a/gamium/typescript/jest/package.json
+++ b/gamium/typescript/jest/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "cross-env": "7.0.3",
-    "dogu-device-client": "0.0.1",
+    "dogu-device-client": "1.1.0",
     "@dogu-tech/jest-environment": "^1.1.4",
     "@jest/globals": "29.6.0",
     "@jest/types": "29.6.0",

--- a/gamium/typescript/jest/package.json
+++ b/gamium/typescript/jest/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "cross-env": "7.0.3",
-    "dogu-device-client": "1.1.0",
+    "dogu-device-client": "1.2.0-rc.1",
     "@dogu-tech/jest-environment": "^1.1.4",
     "@jest/globals": "29.6.0",
     "@jest/types": "29.6.0",

--- a/selenium/python/pytest/requirements.txt
+++ b/selenium/python/pytest/requirements.txt
@@ -1,5 +1,5 @@
 selenium==4.15.2
 python-dotenv==1.0.0
-dogu-device-client==1.1.0
+dogu-device-client==1.2.0rc1
 pytest==7.4.3
 pytest-dogu-sdk==1.0.5

--- a/selenium/python/pytest/requirements.txt
+++ b/selenium/python/pytest/requirements.txt
@@ -1,5 +1,5 @@
 selenium==4.15.2
 python-dotenv==1.0.0
-dogu-device-client==1.0.0
+dogu-device-client==1.1.0
 pytest==7.4.3
 pytest-dogu-sdk==1.0.5

--- a/selenium/python/pytest/web/conftest.py
+++ b/selenium/python/pytest/web/conftest.py
@@ -16,6 +16,7 @@ load_dotenv(str(Path(__file__).parent.parent / '.env.local'))
 
 localhost = "127.0.0.1"
 device_serial = os.environ.get("DOGU_DEVICE_SERIAL")
+device_token = os.environ.get("DOGU_DEVICE_TOKEN")
 device_platform = os.environ.get("DOGU_DEVICE_PLATFORM")
 device_server_port = int(os.environ.get("DOGU_DEVICE_SERVER_PORT", 5001))
 browser_name = os.environ.get("DOGU_BROWSER_NAME")
@@ -31,13 +32,13 @@ pytest_plugins = ["pytest_dogu_report"]
 
 @pytest.fixture(scope="session")
 def device():
-    device_client = DeviceClient(localhost, device_server_port, 30)
+    device_client = DeviceClient(host=localhost, port=device_server_port, token=device_token, timeout=30)
     yield device_client
 
 
 @pytest.fixture(scope="session")
 def host():
-    host_client = DeviceHostClient(localhost, device_server_port, 10 * 60)
+    host_client = DeviceHostClient(host=localhost, port=device_server_port, token=device_token, timeout=10 * 60)
     yield host_client
 
 

--- a/selenium/typescript/jest/package.json
+++ b/selenium/typescript/jest/package.json
@@ -15,7 +15,7 @@
     "@jest/types": "29.6.0",
     "@types/selenium-webdriver": "4.1.16",
     "cross-env": "7.0.3",
-    "dogu-device-client": "1.1.0",
+    "dogu-device-client": "1.2.0-rc.1",
     "dotenv": "16.0.3",
     "jest": "29.6.0",
     "selenium-webdriver": "4.12.0",

--- a/selenium/typescript/jest/package.json
+++ b/selenium/typescript/jest/package.json
@@ -15,7 +15,7 @@
     "@jest/types": "29.6.0",
     "@types/selenium-webdriver": "4.1.16",
     "cross-env": "7.0.3",
-    "dogu-device-client": "0.0.2-rc.1",
+    "dogu-device-client": "1.1.0",
     "dotenv": "16.0.3",
     "jest": "29.6.0",
     "selenium-webdriver": "4.12.0",

--- a/selenium/typescript/jest/web/setup.ts
+++ b/selenium/typescript/jest/web/setup.ts
@@ -14,6 +14,7 @@ import { config } from "dotenv";
 config({ path: ".env.local" });
 
 const Serial = process.env["DOGU_DEVICE_SERIAL"];
+const Token = process.env["DOGU_DEVICE_TOKEN"];
 const DeviceServerPort = parseInt(
   process.env["DOGU_DEVICE_SERVER_PORT"] ?? "5001"
 );
@@ -46,6 +47,7 @@ export let driver: webdriver.ThenableWebDriver;
 beforeAll(async () => {
   const host = new DeviceHostClient({
     port: DeviceServerPort,
+    token: Token,
     timeout: 10 * 60_000,
   });
   console.log("ensure browser and driver");

--- a/webdriverio/typescript/jest/app/setup.ts
+++ b/webdriverio/typescript/jest/app/setup.ts
@@ -6,6 +6,7 @@ import { config } from "dotenv";
 config({ path: ".env.local" });
 
 const Serial = process.env["DOGU_DEVICE_SERIAL"];
+const Token = process.env["DOGU_DEVICE_TOKEN"];
 const AppPath = process.env["DOGU_APP_PATH"];
 const DeviceServerPort = parseInt(
   process.env["DOGU_DEVICE_SERVER_PORT"] ?? "5001"
@@ -23,7 +24,7 @@ export let driver: WebdriverIO.Browser;
 let server: AppiumServerContext | undefined;
 
 beforeAll(async () => {
-  const device = new DeviceClient({ port: DeviceServerPort });
+  const device = new DeviceClient({ port: DeviceServerPort, token: Token });
   server = await device.runAppiumServer(Serial);
   const caps = await device.getAppiumCapabilities(Serial);
   caps["appium:app"] = AppPath;

--- a/webdriverio/typescript/jest/package.json
+++ b/webdriverio/typescript/jest/package.json
@@ -15,7 +15,7 @@
     "@jest/globals": "29.6.0",
     "@jest/types": "29.6.0",
     "cross-env": "7.0.3",
-    "dogu-device-client": "1.1.0",
+    "dogu-device-client": "1.2.0-rc.1",
     "jest": "29.6.0",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",

--- a/webdriverio/typescript/jest/package.json
+++ b/webdriverio/typescript/jest/package.json
@@ -15,7 +15,7 @@
     "@jest/globals": "29.6.0",
     "@jest/types": "29.6.0",
     "cross-env": "7.0.3",
-    "dogu-device-client": "0.0.1",
+    "dogu-device-client": "1.1.0",
     "jest": "29.6.0",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",


### PR DESCRIPTION
## Changed
- dogu-device-client should pass `token` to access device.
- This work was carried out under the influence of cloud test automation work.